### PR TITLE
Use text link foreground colour for verified publisher badges

### DIFF
--- a/templates/b-default-vscode.mustache
+++ b/templates/b-default-vscode.mustache
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "{{ tint.70 }}",
     "extensionBadge.remoteForeground":          "{{ tint.20 }}",
     "extensionIcon.starForeground":             "{{ tint.40 }}",
-    "extensionIcon.preReleaseForeground":       "{{ tint.20 }}",
+    "extensionIcon.verifiedForeground":         "{{ ui.accent1.base }}", 
+    "extensionIcon.preReleaseForeground":       "{{ ui.accent2.base }}",
 
     /* Menu
     */

--- a/templates/b-default-vscode.mustache
+++ b/templates/b-default-vscode.mustache
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "{{ tint.70 }}",
     "extensionBadge.remoteForeground":          "{{ tint.20 }}",
     "extensionIcon.starForeground":             "{{ tint.40 }}",
-    "extensionIcon.verifiedForeground":         "{{ tint.20 }}",
     "extensionIcon.preReleaseForeground":       "{{ tint.20 }}",
 
     /* Menu

--- a/themes/b-theme-dark-coal-lively.json
+++ b/themes/b-theme-dark-coal-lively.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#a8a8a8",
     "extensionBadge.remoteForeground":          "#262626",
     "extensionIcon.starForeground":             "#525252",
-    "extensionIcon.preReleaseForeground":       "#262626",
+    "extensionIcon.verifiedForeground":         "#75aedd", 
+    "extensionIcon.preReleaseForeground":       "#a9a0e6",
 
     /* Menu
     */

--- a/themes/b-theme-dark-coal-lively.json
+++ b/themes/b-theme-dark-coal-lively.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#a8a8a8",
     "extensionBadge.remoteForeground":          "#262626",
     "extensionIcon.starForeground":             "#525252",
-    "extensionIcon.verifiedForeground":         "#262626",
     "extensionIcon.preReleaseForeground":       "#262626",
 
     /* Menu

--- a/themes/b-theme-dark-coal-serene.json
+++ b/themes/b-theme-dark-coal-serene.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#a8a8a8",
     "extensionBadge.remoteForeground":          "#262626",
     "extensionIcon.starForeground":             "#525252",
-    "extensionIcon.preReleaseForeground":       "#262626",
+    "extensionIcon.verifiedForeground":         "#8fabc8", 
+    "extensionIcon.preReleaseForeground":       "#a8a4c8",
 
     /* Menu
     */

--- a/themes/b-theme-dark-coal-serene.json
+++ b/themes/b-theme-dark-coal-serene.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#a8a8a8",
     "extensionBadge.remoteForeground":          "#262626",
     "extensionIcon.starForeground":             "#525252",
-    "extensionIcon.verifiedForeground":         "#262626",
     "extensionIcon.preReleaseForeground":       "#262626",
 
     /* Menu

--- a/themes/b-theme-dark-moss-lively.json
+++ b/themes/b-theme-dark-moss-lively.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#a8a99f",
     "extensionBadge.remoteForeground":          "#262623",
     "extensionIcon.starForeground":             "#52534d",
-    "extensionIcon.verifiedForeground":         "#262623",
     "extensionIcon.preReleaseForeground":       "#262623",
 
     /* Menu

--- a/themes/b-theme-dark-moss-lively.json
+++ b/themes/b-theme-dark-moss-lively.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#a8a99f",
     "extensionBadge.remoteForeground":          "#262623",
     "extensionIcon.starForeground":             "#52534d",
-    "extensionIcon.preReleaseForeground":       "#262623",
+    "extensionIcon.verifiedForeground":         "#75aedd", 
+    "extensionIcon.preReleaseForeground":       "#a9a0e6",
 
     /* Menu
     */

--- a/themes/b-theme-dark-moss-serene.json
+++ b/themes/b-theme-dark-moss-serene.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#a8a99f",
     "extensionBadge.remoteForeground":          "#262623",
     "extensionIcon.starForeground":             "#52534d",
-    "extensionIcon.verifiedForeground":         "#262623",
     "extensionIcon.preReleaseForeground":       "#262623",
 
     /* Menu

--- a/themes/b-theme-dark-moss-serene.json
+++ b/themes/b-theme-dark-moss-serene.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#a8a99f",
     "extensionBadge.remoteForeground":          "#262623",
     "extensionIcon.starForeground":             "#52534d",
-    "extensionIcon.preReleaseForeground":       "#262623",
+    "extensionIcon.verifiedForeground":         "#8fabc8", 
+    "extensionIcon.preReleaseForeground":       "#a8a4c8",
 
     /* Menu
     */

--- a/themes/b-theme-dark-plum-lively.json
+++ b/themes/b-theme-dark-plum-lively.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#aba6b6",
     "extensionBadge.remoteForeground":          "#282430",
     "extensionIcon.starForeground":             "#564f64",
-    "extensionIcon.verifiedForeground":         "#282430",
     "extensionIcon.preReleaseForeground":       "#282430",
 
     /* Menu

--- a/themes/b-theme-dark-plum-lively.json
+++ b/themes/b-theme-dark-plum-lively.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#aba6b6",
     "extensionBadge.remoteForeground":          "#282430",
     "extensionIcon.starForeground":             "#564f64",
-    "extensionIcon.preReleaseForeground":       "#282430",
+    "extensionIcon.verifiedForeground":         "#75aedd", 
+    "extensionIcon.preReleaseForeground":       "#a9a0e6",
 
     /* Menu
     */

--- a/themes/b-theme-dark-plum-serene.json
+++ b/themes/b-theme-dark-plum-serene.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#aba6b6",
     "extensionBadge.remoteForeground":          "#282430",
     "extensionIcon.starForeground":             "#564f64",
-    "extensionIcon.preReleaseForeground":       "#282430",
+    "extensionIcon.verifiedForeground":         "#8fabc8", 
+    "extensionIcon.preReleaseForeground":       "#a8a4c8",
 
     /* Menu
     */

--- a/themes/b-theme-dark-plum-serene.json
+++ b/themes/b-theme-dark-plum-serene.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#aba6b6",
     "extensionBadge.remoteForeground":          "#282430",
     "extensionIcon.starForeground":             "#564f64",
-    "extensionIcon.verifiedForeground":         "#282430",
     "extensionIcon.preReleaseForeground":       "#282430",
 
     /* Menu

--- a/themes/b-theme-dark-warm-lively.json
+++ b/themes/b-theme-dark-warm-lively.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#aea6a8",
     "extensionBadge.remoteForeground":          "#2a2526",
     "extensionIcon.starForeground":             "#595051",
-    "extensionIcon.verifiedForeground":         "#2a2526",
     "extensionIcon.preReleaseForeground":       "#2a2526",
 
     /* Menu

--- a/themes/b-theme-dark-warm-lively.json
+++ b/themes/b-theme-dark-warm-lively.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#aea6a8",
     "extensionBadge.remoteForeground":          "#2a2526",
     "extensionIcon.starForeground":             "#595051",
-    "extensionIcon.preReleaseForeground":       "#2a2526",
+    "extensionIcon.verifiedForeground":         "#75aedd", 
+    "extensionIcon.preReleaseForeground":       "#a9a0e6",
 
     /* Menu
     */

--- a/themes/b-theme-dark-warm-serene.json
+++ b/themes/b-theme-dark-warm-serene.json
@@ -627,7 +627,8 @@
     "extensionBadge.remoteBackground":          "#aea6a8",
     "extensionBadge.remoteForeground":          "#2a2526",
     "extensionIcon.starForeground":             "#595051",
-    "extensionIcon.preReleaseForeground":       "#2a2526",
+    "extensionIcon.verifiedForeground":         "#8fabc8", 
+    "extensionIcon.preReleaseForeground":       "#a8a4c8",
 
     /* Menu
     */

--- a/themes/b-theme-dark-warm-serene.json
+++ b/themes/b-theme-dark-warm-serene.json
@@ -627,7 +627,6 @@
     "extensionBadge.remoteBackground":          "#aea6a8",
     "extensionBadge.remoteForeground":          "#2a2526",
     "extensionIcon.starForeground":             "#595051",
-    "extensionIcon.verifiedForeground":         "#2a2526",
     "extensionIcon.preReleaseForeground":       "#2a2526",
 
     /* Menu


### PR DESCRIPTION
### Removed
- The definition for verified extension publisher badges, allowing the theme to fall back to the default of using [link foreground color](https://github.com/microsoft/vscode/blob/3e753b10dd0d45eba51fc8955482bda4344503f3/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts#L796)

Before:
<img width="253" alt="Screenshot 2023-08-17 at 23 47 23" src="https://github.com/surfinzap/b-theme-vscode/assets/286404/842f743c-60a4-4f36-a7db-f358d16d199e">

After:
<img width="252" alt="Screenshot 2023-08-17 at 23 47 38" src="https://github.com/surfinzap/b-theme-vscode/assets/286404/0d9cc084-4af5-4def-946f-058706ed2ee9">